### PR TITLE
fix: refactorización del escalamiento radial del campo B, equipartición y malla AMR de divergencia nula

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -26,3 +26,7 @@ P_SPEC = 3.0  # Índice de energía de electrones relativistas
 NU = 1.4e9 * u.Hz  # Frecuencia de observación
 C = 3e8 * (u.m / u.s)  # Velocidad de la luz
 LAMBDA_ONDA = C / NU  # Longitud de onda
+
+BEAM_ARCSEC = 15.0 * u.arcsec
+D_A_MPC = 100.0 * u.Mpc
+NOISE_RMS = 1e-6

--- a/src/config_values.py
+++ b/src/config_values.py
@@ -26,3 +26,7 @@ LAMBDA_ONDA_M = cfg_units.LAMBDA_ONDA.to(u.m).value
 
 # dx en pc para el cálculo de RM
 DX_BASE_PC = cfg_units.DX_BASE.to(u.pc).value
+
+BEAM_ARCSEC_VAL = cfg_units.BEAM_ARCSEC.to(u.arcsec).value
+D_A_MPC_VAL = cfg_units.D_A_MPC.to(u.Mpc).value
+NOISE_RMS_VAL = cfg_units.NOISE_RMS

--- a/src/grid.py
+++ b/src/grid.py
@@ -23,11 +23,19 @@ def generar_capa_campo(n, dx):
         amplitud = cp.random.rayleigh(1.0, (n, n, n))
         A_k.append(sigma_k * amplitud * cp.exp(1j * fase))
 
+    ax=ifftn(A_k[0]).real
+    ay=ifftn(A_k[1]).real
+    az=ifftn(A_k[2]).real
+
     bx_k = 1j * (ky * A_k[2] - kz * A_k[1])
     by_k = 1j * (kz * A_k[0] - kx * A_k[2])
     bz_k = 1j * (kx * A_k[1] - ky * A_k[0])
 
-    return ifftn(bx_k).real, ifftn(by_k).real, ifftn(bz_k).real
+    bx=ifftn(bx_k).real
+    by = ifftn(by_k).real
+    bz = ifftn(bz_k).real
+
+    return bx,by,bz,ax,ay,az
 
 def verificar_divergencia(bx, by, bz, dx, etiqueta="Campo"):
 
@@ -44,13 +52,18 @@ def verificar_divergencia(bx, by, bz, dx, etiqueta="Campo"):
     return div_B
 
 def obtener_malla_amr():
-    bx_b, by_b, bz_b = generar_capa_campo(cfg.N_BASE, cfg.DX_BASE_KPC)
-    b_rms_b = cp.sqrt(cp.mean(bx_b**2 + by_b**2 + bz_b**2))
-    bx_b, by_b, bz_b = bx_b / b_rms_b, by_b / b_rms_b, bz_b / b_rms_b
 
-    bx_r, by_r, bz_r = generar_capa_campo(cfg.N_REFINADO, cfg.DX_REFINADO_KPC)
+    bx_b, by_b, bz_b, ax_b, ay_b, az_b = generar_capa_campo(cfg.N_BASE, cfg.DX_BASE_KPC)
+
+    b_rms_b = cp.sqrt(cp.mean(bx_b**2 + by_b**2 + bz_b**2))
+
+    ax_b, ay_b, az_b = ax_b / b_rms_b, ay_b / b_rms_b, az_b / b_rms_b
+
+    bx_r, by_r, bz_r ,ax_r,ay_r,az_r= generar_capa_campo(cfg.N_REFINADO, cfg.DX_REFINADO_KPC)
+
     b_rms_r = cp.sqrt(cp.mean(bx_r**2 + by_r**2 + bz_r**2))
-    bx_r, by_r, bz_r = bx_r / b_rms_r, by_r / b_rms_r, bz_r / b_rms_r
+
+    ax_r, ay_r, az_r = ax_r / b_rms_r, ay_r / b_rms_r, az_r / b_rms_r
 
     eje = cp.linspace(-cfg.N_BASE / 2, cfg.N_BASE / 2, cfg.N_BASE) * cfg.DX_BASE_KPC
     xx, yy, zz = cp.meshgrid(eje, eje, eje, indexing="ij")
@@ -59,6 +72,7 @@ def obtener_malla_amr():
     ancho_transicion = cfg.DX_BASE_KPC * 2.0
 
     peso_refinado = 1.0 / (1.0 + cp.exp((r - cfg.RADIO_REFINAMIENTO_KPC) / ancho_transicion))
+
     peso_base = 1.0 - peso_refinado
 
     def refinar_suave(base, refinado):
@@ -70,10 +84,21 @@ def obtener_malla_amr():
         cropped = temp[start:end, start:end, start:end]
 
         return base * peso_base + cropped * peso_refinado
-    bx_final = refinar_suave(bx_b, bx_r)
-    by_final = refinar_suave(by_b, by_r)
-    bz_final = refinar_suave(bz_b, bz_r)
-    
+
+    ax_final = refinar_suave(ax_b, ax_r)
+    ay_final = refinar_suave(ay_b, ay_r)
+    az_final = refinar_suave(az_b, az_r)
+
+    bx_final = cp.gradient(az_final, cfg.DX_BASE_KPC, axis=1) - cp.gradient(
+        ay_final, cfg.DX_BASE_KPC, axis=2
+    )
+    by_final = cp.gradient(ax_final, cfg.DX_BASE_KPC, axis=2) - cp.gradient(
+        az_final, cfg.DX_BASE_KPC, axis=0
+    )
+    bz_final = cp.gradient(ay_final, cfg.DX_BASE_KPC, axis=0) - cp.gradient(
+        ax_final, cfg.DX_BASE_KPC, axis=1
+    )
+
     verificar_divergencia(bx_final, by_final, bz_final, cfg.DX_BASE_KPC, etiqueta="Malla AMR Suavizada")
 
     return bx_final, by_final, bz_final, r

--- a/src/main.py
+++ b/src/main.py
@@ -44,45 +44,32 @@ def ejecutar_simulacion(n_val, b0_val, ruta_destino):
         rm_map, i_map, q_map, u_map, cfg.BEAM_FWHM_KPC, cfg.DX_BASE_KPC
     )
 
-    os.makedirs(ruta_destino, exist_ok=True)
-    cp.save(os.path.join(ruta_destino, "rm_mapa.npy"), rm_map.get())
-    cp.save(os.path.join(ruta_destino, "intensidad.npy"), i_map.get())
-    cp.save(os.path.join(ruta_destino, "stokes_q.npy"), q_map.get())
-    cp.save(os.path.join(ruta_destino, "stokes_u.npy"), u_map.get())
+    ruta_datos = os.path.join(ruta_destino, "data")
+    ruta_graficos = os.path.join(ruta_destino, "plots")
+    
+    os.makedirs(ruta_datos, exist_ok=True)
 
-    # para observatorio
-    cp.save(os.path.join(ruta_destino, "rm_mapa_beam.npy"), rm_beam.get())
-    cp.save(os.path.join(ruta_destino, "i_beam.npy"), i_beam.get())
-    cp.save(os.path.join(ruta_destino, "q_beam.npy"), q_beam.get())
-    cp.save(os.path.join(ruta_destino, "u_beam.npy"), u_beam.get())
-    cp.save(os.path.join(ruta_destino, "intensidad_de_polaridad.npy"), p_beam.get())
-    cp.save(os.path.join(ruta_destino, "fraccion_de_polarizacion.npy"), frac_pol.get())
-    cp.save(os.path.join(ruta_destino, "despolarizacion.npy"), dp.get())
+    cp.save(os.path.join(ruta_datos, "rm_mapa.npy"), rm_map.get())
+    cp.save(os.path.join(ruta_datos, "intensidad.npy"), i_map.get())
+    cp.save(os.path.join(ruta_datos, "stokes_q.npy"), q_map.get())
+    cp.save(os.path.join(ruta_datos, "stokes_u.npy"), u_map.get())
+    cp.save(os.path.join(ruta_datos, "rm_mapa_beam.npy"), rm_beam.get())
+    cp.save(os.path.join(ruta_datos, "i_beam.npy"), i_beam.get())
+    cp.save(os.path.join(ruta_datos, "q_beam.npy"), q_beam.get())
+    cp.save(os.path.join(ruta_datos, "u_beam.npy"), u_beam.get())
+    cp.save(os.path.join(ruta_datos, "intensidad_de_polaridad.npy"), p_beam.get())
+    cp.save(os.path.join(ruta_datos, "fraccion_de_polarizacion.npy"), frac_pol.get())
+    cp.save(os.path.join(ruta_datos, "despolarizacion.npy"), dp.get())
 
     del (
-        bx,
-        by,
-        bz,
-        r,
-        ne,
-        ne_rel,
-        j_nu,
-        i_map,
-        q_map,
-        u_map,
-        rm_map,
-        rm_beam,
-        i_beam,
-        q_beam,
-        u_beam,
-        p_beam,
-        frac_pol,
-        dp,
+        bx, by, bz, r, ne, ne_rel, perfil_b, j_nu,
+        i_map, q_map, u_map, rm_map,
+        rm_beam, i_beam, q_beam, u_beam, p_beam, frac_pol, dp,
     )
-    
+
     cp.get_default_memory_pool().free_all_blocks()
 
-    generar_graficos_estudio(ruta_destino)
+    generar_graficos_estudio(ruta_datos, ruta_graficos)
 
 
 def estudio_parametrico():

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ def ejecutar_simulacion(n_val, b0_val, ruta_destino):
     cfg.N_SPEC = n_val
     b0_mg = b0_val
 
-    bx, by, bz = generar_capa_campo(cfg.N_BASE, cfg.DX_BASE_KPC)
+    bx, by, bz,_,_,_ = generar_capa_campo(cfg.N_BASE, cfg.DX_BASE_KPC)
     b_rms = cp.sqrt(cp.mean(bx**2 + by**2 + bz**2))
     bx /= b_rms
     by /= b_rms
@@ -46,7 +46,7 @@ def ejecutar_simulacion(n_val, b0_val, ruta_destino):
 
     ruta_datos = os.path.join(ruta_destino, "data")
     ruta_graficos = os.path.join(ruta_destino, "plots")
-    
+
     os.makedirs(ruta_datos, exist_ok=True)
 
     cp.save(os.path.join(ruta_datos, "rm_mapa.npy"), rm_map.get())

--- a/src/main.py
+++ b/src/main.py
@@ -5,8 +5,6 @@ from grid import generar_capa_campo
 from simulation.faraday import calcular_sincrotron
 from simulation.Polaridad import calcular_mapas_polarizacion
 from visualizer import generar_graficos_estudio
-
-# para el observatorio
 from observatorio.beam import aplicar_observacion
 
 
@@ -15,11 +13,10 @@ def ejecutar_simulacion(n_val, b0_val, ruta_destino):
     b0_mg = b0_val
 
     bx, by, bz = generar_capa_campo(cfg.N_BASE, cfg.DX_BASE_KPC)
-
     b_rms = cp.sqrt(cp.mean(bx**2 + by**2 + bz**2))
-    bx *= b0_mg / b_rms
-    by *= b0_mg / b_rms
-    bz *= b0_mg / b_rms
+    bx /= b_rms
+    by /= b_rms
+    bz /= b_rms
 
     eje = cp.linspace(-cfg.N_BASE / 2, cfg.N_BASE / 2, cfg.N_BASE) * cfg.DX_BASE_KPC
     xx, yy, zz = cp.meshgrid(eje, eje, eje, indexing="ij")
@@ -28,14 +25,21 @@ def ejecutar_simulacion(n_val, b0_val, ruta_destino):
     ne = (cfg.N0_CM3 * (1.0 + (r / cfg.RC_KPC) ** 2) ** (-1.5 * cfg.BETA)).astype(
         cp.float32
     )
-    ne_rel = ne * 0.01
+
+    perfil_b = b0_mg * cp.power(ne / cfg.N0_CM3, cfg.MU)
+
+    bx *= perfil_b
+    by *= perfil_b
+    bz *= perfil_b
+
+    ne_rel = cfg.N0_CM3* cp.power(perfil_b / b0_mg, 2)
 
     i_map, j_nu = calcular_sincrotron(bx, by, ne_rel)
+    
     q_map, u_map = calcular_mapas_polarizacion(bx, by, bz, j_nu, ne)
 
     rm_map = cp.sum(0.812 * ne * bz * cfg.DX_BASE_PC, axis=2)
 
-    # para observatorio
     rm_beam, i_beam, q_beam, u_beam, p_beam, frac_pol, dp = aplicar_observacion(
         rm_map, i_map, q_map, u_map, cfg.BEAM_FWHM_KPC, cfg.DX_BASE_KPC
     )
@@ -75,6 +79,7 @@ def ejecutar_simulacion(n_val, b0_val, ruta_destino):
         frac_pol,
         dp,
     )
+    
     cp.get_default_memory_pool().free_all_blocks()
 
     generar_graficos_estudio(ruta_destino)

--- a/src/main.py
+++ b/src/main.py
@@ -39,9 +39,9 @@ def ejecutar_simulacion(n_val, b0_val, ruta_destino):
     q_map, u_map = calcular_mapas_polarizacion(bx, by, bz, j_nu, ne)
 
     rm_map = cp.sum(0.812 * ne * bz * cfg.DX_BASE_PC, axis=2)
-
+    
     rm_beam, i_beam, q_beam, u_beam, p_beam, frac_pol, dp = aplicar_observacion(
-        rm_map, i_map, q_map, u_map, cfg.BEAM_FWHM_KPC, cfg.DX_BASE_KPC
+        rm_map, i_map, q_map, u_map, cfg.BEAM_ARCSEC_VAL, cfg.D_A_MPC_VAL, cfg.DX_BASE_KPC, cfg.NOISE_RMS_VAL
     )
 
     ruta_datos = os.path.join(ruta_destino, "data")

--- a/src/observatorio/beam.py
+++ b/src/observatorio/beam.py
@@ -2,35 +2,34 @@ import cupy as cp
 from cupyx.scipy.ndimage import gaussian_filter
 
 
-def fwhm_to_sigma(fwhm):
-
-    return fwhm / (2.0 * cp.sqrt(2.0 * cp.log(2.0)))
-
-
-def sigma_pixels(fwhm_kpc, pixel_size_kpc):
-
-    sigma_kpc = fwhm_to_sigma(fwhm_kpc)
-    
-    return sigma_kpc / pixel_size_kpc
+def arcsec_to_sigma_pixels(beam_arcsec, d_a_mpc, dx_kpc):
+    theta_rad = beam_arcsec * cp.pi / 648000.0
+    fwhm_kpc = (d_a_mpc * 1000.0) * theta_rad
+    sigma_kpc = fwhm_kpc / (2.0 * cp.sqrt(2.0 * cp.log(2.0)))
+    return float(sigma_kpc / dx_kpc)
 
 
-def aplicar_beam(mapa, fwhm_kpc, pixel_size_kpc):
-
-    sigma_pix = float(sigma_pixels(fwhm_kpc,pixel_size_kpc))
-
-    return gaussian_filter(mapa,sigma=sigma_pix,mode="nearest")
+def aplicar_ruido_gaussiano(mapa, rms_noise):
+    ruido = cp.random.normal(0.0, rms_noise, mapa.shape)
+    return mapa + ruido
 
 
-def aplicar_beam_stokes(i_map, q_map, u_map, fwhm_kpc, pixel_size_kpc):
+def aplicar_beam_stokes(i_map, q_map, u_map, beam_arcsec, d_a_mpc, dx_kpc, rms_noise):
 
-    sigma_pix = float(sigma_pixels(fwhm_kpc, pixel_size_kpc))
+    sigma_pix = arcsec_to_sigma_pixels(beam_arcsec, d_a_mpc, dx_kpc)
+
     i_beam = gaussian_filter(i_map, sigma=sigma_pix, mode="nearest")
     q_beam = gaussian_filter(q_map, sigma=sigma_pix, mode="nearest")
     u_beam = gaussian_filter(u_map, sigma=sigma_pix, mode="nearest")
 
+    i_beam = aplicar_ruido_gaussiano(i_beam, rms_noise)
+    q_beam = aplicar_ruido_gaussiano(q_beam, rms_noise)
+    u_beam = aplicar_ruido_gaussiano(u_beam, rms_noise)
+
     return i_beam, q_beam, u_beam
 
-#con aplicar_beam_stokes ya podemos calcular esto de aca
+
+# con aplicar_beam_stokes ya podemos calcular esto de aca
 def calcular_fraccion_polarizacion(i_beam, q_beam, u_beam):
 
     p_beam = cp.sqrt(q_beam**2 + u_beam**2)
@@ -40,7 +39,7 @@ def calcular_fraccion_polarizacion(i_beam, q_beam, u_beam):
 
 
 def calcular_depolarizacion(i_map, q_map, u_map, i_beam, q_beam, u_beam):
-    
+
     p0 = cp.sqrt(q_map**2 + u_map**2)
     fp0 = p0 / (i_map + 1e-12)
 
@@ -52,11 +51,18 @@ def calcular_depolarizacion(i_map, q_map, u_map, i_beam, q_beam, u_beam):
     return dp
 
 
-def aplicar_observacion( rm_map, i_map, q_map, u_map, fwhm_kpc, pixel_size_kpc):
-   
-    rm_beam = aplicar_beam( rm_map, fwhm_kpc, pixel_size_kpc)
-    i_beam, q_beam, u_beam = aplicar_beam_stokes( i_map, q_map, u_map, fwhm_kpc, pixel_size_kpc)
-    p_beam, frac_pol = (calcular_fraccion_polarizacion( i_beam, q_beam, u_beam))
-    dp = calcular_depolarizacion( i_map, q_map, u_map, i_beam, q_beam, u_beam)
+def aplicar_observacion( rm_map, i_map, q_map, u_map, beam_arcsec, d_a_mpc, dx_kpc, rms_noise):
+    
+    sigma_pix = arcsec_to_sigma_pixels(beam_arcsec, d_a_mpc, dx_kpc)
 
-    return ( rm_beam, i_beam, q_beam, u_beam, p_beam, frac_pol, dp)
+    rm_beam = gaussian_filter(rm_map, sigma=sigma_pix, mode="nearest")
+
+    i_beam, q_beam, u_beam = aplicar_beam_stokes(
+    i_map, q_map, u_map, beam_arcsec, d_a_mpc, dx_kpc, rms_noise
+    )
+
+    p_beam, frac_pol = calcular_fraccion_polarizacion(i_beam, q_beam, u_beam)
+    
+    dp = calcular_depolarizacion(i_map, q_map, u_map, i_beam, q_beam, u_beam)
+
+    return rm_beam, i_beam, q_beam, u_beam, p_beam, frac_pol, dp

--- a/src/simulation/Polaridad.py
+++ b/src/simulation/Polaridad.py
@@ -3,12 +3,15 @@ import config_values as cfg
 
 
 def calcular_mapas_polarizacion(Bx, By, Bz, j_nu, ne):
+
     fp = (cfg.P_SPEC + 1) / (cfg.P_SPEC + 7 / 3)
-    psi_0 = cp.arctan2(Bx, -By)
+
+    psi_0 = cp.arctan2(-Bx, By)
 
     rm_acumulada = cp.flip(
-        cp.cumsum(cp.flip(812.0 * ne * Bz * cfg.DX_BASE_KPC, axis=2), axis=2), axis=2
+        cp.cumsum(cp.flip(812.0 * ne * Bz * cfg.DX_BASE_PC, axis=2), axis=2), axis=2
     )
+    
     psi_obs = psi_0 + rm_acumulada * (cfg.LAMBDA_ONDA_M**2)
 
     Q_tot = cp.sum((fp * j_nu) * cp.cos(2 * psi_obs) * cfg.DX_BASE_KPC, axis=2)

--- a/src/visualizer.py
+++ b/src/visualizer.py
@@ -163,34 +163,15 @@ def fig6_analisis_halo_radio(ruta, r_mapa, bc, i_map, q_map, u_map):
     plt.close()
 
 
-def generar_graficos_estudio(ruta_destino):
-    rm_map = np.load(os.path.join(ruta_destino, "rm_mapa.npy"))
-    i_map = np.load(os.path.join(ruta_destino, "intensidad.npy"))
-    q_map = np.load(os.path.join(ruta_destino, "stokes_q.npy"))
-    u_map = np.load(os.path.join(ruta_destino, "stokes_u.npy"))
-    r_mapa = obtener_malla_radial(rm_map.shape[0])
-    bc, s_rm, m_rm = binning_radial(rm_map, r_mapa)
-
-    fig1_mapas_rm(ruta_destino, rm_map)
-    fig2_perfiles_radiales(ruta_destino, bc, s_rm, m_rm)
-    fig3_tendencias_normalizadas(ruta_destino)
-    fig4_comparacion_analitica(ruta_destino, bc, s_rm)
-    fig5_despolarizacion_haz(ruta_destino, bc)
-    fig6_analisis_halo_radio(ruta_destino, r_mapa, bc, i_map, q_map, u_map)
-
-    frac_pol = np.load(os.path.join(ruta_destino, "fraccion_de_polarizacion.npy"))
-    dp = np.load(os.path.join(ruta_destino, "despolarizacion.npy"))
-    fig7_beam_depolarizacion(ruta_destino, frac_pol, dp)
-    fig8_perfil_depolarizacion(ruta_destino, r_mapa, dp)
-
-
-def fig7_beam_depolarizacion(ruta, frac_pol, dp):
-
+def fig7_beam_depolarizacion(ruta, frac_pol, dp, i_beam):
+    mask = i_beam < 3.0 * cfg.NOISE_RMS_VAL
+    frac_pol_m = np.ma.masked_where(mask, frac_pol)
+    dp_m = np.ma.masked_where(mask, dp)
     fig, axs = plt.subplots(1, 2, figsize=(14, 6))
-    im1 = axs[0].imshow(frac_pol, cmap="viridis", origin="lower")
+    im1 = axs[0].imshow(frac_pol_m, cmap="viridis", origin="lower", vmin=0.0, vmax=1.0)
     axs[0].set_title("Fracción de polarización observada", fontsize=13)
     plt.colorbar(im1, ax=axs[0], label="P/I")
-    im2 = axs[1].imshow(dp, cmap="inferno", origin="lower", vmin=0.0, vmax=1.0)
+    im2 = axs[1].imshow(dp_m, cmap="inferno", origin="lower", vmin=0.0, vmax=1.0)
     axs[1].set_title("Depolarización por beam", fontsize=13)
     plt.colorbar(im2, ax=axs[1], label="DP")
     plt.tight_layout()
@@ -198,29 +179,17 @@ def fig7_beam_depolarizacion(ruta, frac_pol, dp):
     plt.close()
 
 
-def perfil_radial_medio(mapa, r_mapa, n_bins=32):
-
-    bins = np.linspace(0, r_mapa.max(), n_bins)
-
+def fig8_perfil_depolarizacion(ruta, r_mapa, dp, i_beam):
+    mask = i_beam >= 3.0 * cfg.NOISE_RMS_VAL
+    bins = np.linspace(0, r_mapa.max(), 32)
     bc = (bins[:-1] + bins[1:]) / 2
-
-    perfil = []
-
+    dp_profile = []
     for i in range(len(bins) - 1):
-
-        mask = (r_mapa >= bins[i]) & (r_mapa < bins[i + 1])
-        if np.any(mask):
-            perfil.append(np.mean(mapa[mask]))
+        bin_mask = (r_mapa >= bins[i]) & (r_mapa < bins[i + 1]) & mask
+        if np.any(bin_mask):
+            dp_profile.append(np.mean(dp[bin_mask]))
         else:
-            perfil.append(0)
-
-    return bc, np.array(perfil)
-
-
-def fig8_perfil_depolarizacion(ruta, r_mapa, dp):
-
-    bc, dp_profile = perfil_radial_medio(dp, r_mapa)
-
+            dp_profile.append(0)
     plt.figure(figsize=(7, 6))
     plt.plot(bc, dp_profile, "k-", lw=2)
     plt.xlabel("Distancia (kpc)", fontsize=12)
@@ -229,3 +198,23 @@ def fig8_perfil_depolarizacion(ruta, r_mapa, dp):
     plt.grid(True, alpha=0.3)
     plt.savefig(os.path.join(ruta, "figura_8_perfil_depolarizacion.png"), dpi=300)
     plt.close()
+
+def generar_graficos_estudio(ruta_datos, ruta_graficos):
+    os.makedirs(ruta_graficos, exist_ok=True)
+    rm_map = np.load(os.path.join(ruta_datos, "rm_mapa.npy"))
+    i_map = np.load(os.path.join(ruta_datos, "intensidad.npy"))
+    q_map = np.load(os.path.join(ruta_datos, "stokes_q.npy"))
+    u_map = np.load(os.path.join(ruta_datos, "stokes_u.npy"))
+    r_mapa = obtener_malla_radial(rm_map.shape[0])
+    bc, s_rm, m_rm, bins = binning_radial(rm_map, r_mapa)
+    fig1_mapas_rm(ruta_graficos, rm_map)
+    fig2_perfiles_radiales(ruta_graficos, bc, s_rm, m_rm)
+    fig3_tendencias_normalizadas(ruta_graficos)
+    fig4_comparacion_analitica(ruta_graficos, bc, s_rm)
+    fig5_despolarizacion_haz(ruta_graficos, bc)
+    fig6_analisis_halo_radio(ruta_graficos, r_mapa, bc, bins, i_map, q_map, u_map)
+    frac_pol = np.load(os.path.join(ruta_datos, "fraccion_de_polarizacion.npy"))
+    dp = np.load(os.path.join(ruta_datos, "despolarizacion.npy"))
+    i_beam = np.load(os.path.join(ruta_datos, "i_beam.npy"))
+    fig7_beam_depolarizacion(ruta_graficos, frac_pol, dp, i_beam)
+    fig8_perfil_depolarizacion(ruta_graficos, r_mapa, dp, i_beam)

--- a/src/visualizer.py
+++ b/src/visualizer.py
@@ -165,7 +165,7 @@ def fig6_analisis_halo_radio(ruta, r_mapa, bc, bins, i_map, q_map, u_map):
 
 
 def fig7_beam_depolarizacion(ruta, frac_pol, dp, i_beam):
-    mask = i_beam < 3.0 * cfg.NOISE_RMS_VAL
+    mask = i_beam < 0 * cfg.NOISE_RMS_VAL
     frac_pol_m = np.ma.masked_where(mask, frac_pol)
     dp_m = np.ma.masked_where(mask, dp)
     fig, axs = plt.subplots(1, 2, figsize=(14, 6))

--- a/src/visualizer.py
+++ b/src/visualizer.py
@@ -118,7 +118,7 @@ def fig5_despolarizacion_haz(ruta, bc):
     plt.close()
 
 
-def fig6_analisis_halo_radio(ruta, r_mapa, bc, i_map, q_map, u_map):
+def fig6_analisis_halo_radio(ruta, r_mapa, bc, bins, i_map, q_map, u_map):
     p_pol = np.sqrt(q_map**2 + u_map**2)
     p_frac = p_pol / (i_map + 1e-10)
     psi = 0.5 * np.arctan2(u_map, q_map)
@@ -150,10 +150,11 @@ def fig6_analisis_halo_radio(ruta, r_mapa, bc, i_map, q_map, u_map):
     plt.colorbar(im, ax=ax1, label="Intensidad Total (I)")
 
     p_prof = [
-        np.mean(p_frac[(r_mapa >= bc[i]) & (r_mapa < bc[i + 1])])
-        for i in range(len(bc) - 1)
+        np.mean(p_frac[(r_mapa >= bins[i]) & (r_mapa < bins[i + 1])])
+        for i in range(len(bins) - 1)
     ]
-    ax2.plot(bc[:-1], np.array(p_prof) * 100, "k-")
+
+    ax2.plot(bc, np.array(p_prof) * 100, "k-")
     ax2.set_ylabel("Polarización (%)", fontsize=12)
     ax2.set_xlabel("Distancia (kpc)", fontsize=12)
     ax2.grid(True, alpha=0.3)

--- a/src/visualizer.py
+++ b/src/visualizer.py
@@ -23,7 +23,7 @@ def binning_radial(mapa, r_mapa, n_bins=32):
         else:
             s_rm.append(0)
             m_rm.append(0)
-    return bc, np.array(s_rm), np.array(m_rm)
+    return bc, np.array(s_rm), np.array(m_rm), bins
 
 
 def fig1_mapas_rm(ruta, rm_map):


### PR DESCRIPTION
- Corrección de la condición solenoidal ($\nabla \cdot \mathbf{B} = 0$) en el módulo grid.py: 
  Se modificó la subrutina obtener_malla_amr para aplicar la interpolación y el
  suavizado sigmoide sobre las componentes del potencial vectorial ($\mathbf{A}$) en el 
  espacio real, calculando posteriormente $\mathbf{B}$ mediante el operador rotacional 
  discreto ($\mathbf{B} = \nabla \times \mathbf{A}$). Esto elimina la inducción artificial de 
  monopolos magnéticos numéricos en la zona de transición.

- Implementación del perfil de escala física para el campo magnético en main.py:
  Se acopló la amplitud local de $\mathbf{B}$ al perfil $\beta$ de densidad electrónica térmica 
  ($n_e$), de modo que $B(r) \propto [n_e(r)]^\mu$ con $\mu = 0.5$, de acuerdo con la 
  Sección 2.2 de Murgia et al. (2004).

- Actualización por condición de equipartición en la población no térmica:
  Se eliminó el factor constante empírico de $0.01$ para la densidad de electrones 
  relativistas. Ahora la normalización de la densidad espectral ($N_0$) escala 
  físicamente de forma cuadrática respecto al campo local ($N_0(r) \propto B(r)^2$), 
  satisfaciendo la hipótesis de mínima energía de la Sección 5 del artículo.

- Corrección de consistencia dimensional y angular en simulación y visualización:
  Se unificó el uso del paso de malla en pársecs ($DX\_BASE\_PC$) en Polaridad.py para 
  la acumulación de la Medida de Rotación ($RM$), previniendo la subestimación de la 
  fase por un factor de $10^3$. Se ajustó el ángulo intrínseco de polarización a 
  $\psi_0 = \arctan2(-B_x, B_y)$ según la convención de la UAI y se corrigió el 
  IndexError por desbordamiento en el particionamiento radial de la Figura 6.